### PR TITLE
Allow users to pass in fallback function

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,22 +15,28 @@ You can include the standalone build by referencing it in your page:
 To use it, call the `window.openregisterPickerEngine` function, providing a link to your OpenRegister data file:
 
 ```js
-var suggest = openregisterPickerEngine('/public/data/location-picker-graph.json')
+var suggest = openregisterPickerEngine({ url: '/public/data/location-picker-graph.json' })
 ```
 
 The function will immediately return a `suggest` function and perform an asynchronous [fetch](https://github.github.io/fetch/) call to retrieve and parse the provided JSON.
 
 ## API Documentation
 
-### `openregisterPickerEngine(url, [callback])`
+### `openregisterPickerEngine(options)`
 
-#### `url`
+#### `options.url`
 
 Type: `string`
 
 The path to the OpenRegister data file.
 
-#### `callback`
+#### `options.fallback`
+
+Type: `function`
+
+An optional function that will be used as the `suggest` in the meantime until the graph loads or in the event that the graph fails to load.
+
+#### `options.callback`
 
 Type: `function`
 
@@ -64,7 +70,7 @@ The `path` is an optional string specifying the last node that the engine had to
 For example, if you seed the engine with the data for the Location Picker, and search for `deut`:
 
 ```js
-> const suggest = openregisterPickerEngine('location-picker-graph.json')
+> const suggest = openregisterPickerEngine({ url: 'location-picker-graph.json' })
 > suggest('deut', (results) => console.log(results))
 [
   {

--- a/__mocks__/fetch.js
+++ b/__mocks__/fetch.js
@@ -6,8 +6,12 @@ function text () {
   })
 }
 
-export default function fetch () {
-  return new Promise((resolve) => {
-    resolve({ text })
+export default function fetch (url) {
+  return new Promise((resolve, reject) => {
+    if (url === 'fail') {
+      reject({ error: 'Failed to fetch URL' })
+    } else {
+      resolve({ text })
+    }
   })
 }

--- a/examples/index.html
+++ b/examples/index.html
@@ -79,7 +79,7 @@
         element: element,
         id: id,
         minLength: 2,
-        source: openregisterPickerEngine(dataFilePath),
+        source: openregisterPickerEngine({ url: dataFilePath }),
         templates: {
           inputValue: inputValueTemplate,
           suggestion: suggestionTemplate

--- a/examples/index.html
+++ b/examples/index.html
@@ -58,7 +58,7 @@
       <div id="default-container" class="autocomplete-wrapper"></div>
     </main>
     <script type="text/javascript" src="../dist/picker-engine.min.js"></script>
-    <script type="text/javascript" src="https://unpkg.com/accessible-typeahead@0.4.0"></script>
+    <script type="text/javascript" src="https://unpkg.com/accessible-typeahead@0.4.2"></script>
     <script type="text/javascript">
       var element = document.querySelector('#default-container')
       var id = 'default'

--- a/src/index.js
+++ b/src/index.js
@@ -239,18 +239,21 @@ function createSuggestionEngine (graph) {
   return suggest
 }
 
-function openregisterPickerEngine (pathToGraph, callback) {
+function openregisterPickerEngine ({ url, fallback, callback }) {
   // This will be reassigned when the graph is fetched and ready.
-  var suggest = function (query, syncResults) {
+  var suggest = fallback || function (query, syncResults) {
     syncResults([])
   }
 
-  fetch(pathToGraph)
+  fetch(url)
     .then((response) => response.text())
     .then((graphText) => JSON.parse(graphText))
     .then((graph) => {
       suggest = createSuggestionEngine(graph)
       if (callback) { callback() }
+    })
+    .catch((err) => {
+      if (callback) { callback(err) }
     })
 
   function suggestWrapper () {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -32,7 +32,7 @@ const openregisterPickerEngine = require('./index').default
 
 describe('openregisterPickerEngine', () => {
   test('returns a suggestion function', (done) => {
-    const suggest = openregisterPickerEngine('some-path.json')
+    const suggest = openregisterPickerEngine({ url: 'some-path.json' })
     expect(typeof suggest).toEqual('function')
     const suggestResult = suggest('whatever', (results) => {
       expect(results).toEqual([])
@@ -45,8 +45,8 @@ describe('openregisterPickerEngine', () => {
 describe('createSuggestionEngine', () => {
   let suggest
 
-  beforeAll((done) => {
-    suggest = openregisterPickerEngine('some-path.json', done)
+  beforeAll((callback) => {
+    suggest = openregisterPickerEngine({ url: 'some-path.json', callback })
   })
 
   test('suggests nothing for empty query', (done) => {
@@ -81,6 +81,21 @@ describe('createSuggestionEngine', () => {
         {name: 'Ukraine', path: ''}
       ])
       done()
+    })
+  })
+
+  test('suggests using fallback when failing to fetch', (done) => {
+    const fallback = (query, syncResults) => syncResults('fallback')
+    suggest = openregisterPickerEngine({
+      url: 'fail',
+      fallback,
+      callback: (err) => {
+        expect(err).toEqual({ error: 'Failed to fetch URL' })
+        suggest('uk', (results) => {
+          expect(results).toEqual('fallback')
+          done()
+        })
+      }
     })
   })
 })


### PR DESCRIPTION
This allows users to supply a better default while the graph is loading or in the event that it fails to load.

Closes #1.